### PR TITLE
remove out of date remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,6 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2
-Remotes: 
-    emilyriederer/projmgr/tree/next-release
 Imports: 
     googledrive,
     here,


### PR DESCRIPTION
I couldn't install the package with remotes::install_github() due to this line